### PR TITLE
Add Avalonia P2P voice chat sample

### DIFF
--- a/VoiceChatApp/App.axaml
+++ b/VoiceChatApp/App.axaml
@@ -1,0 +1,10 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="VoiceChatApp.App"
+             RequestedThemeVariant="Default">
+             <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
+
+    <Application.Styles>
+        <FluentTheme />
+    </Application.Styles>
+</Application>

--- a/VoiceChatApp/App.axaml.cs
+++ b/VoiceChatApp/App.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+
+namespace VoiceChatApp;
+
+public partial class App : Application
+{
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.MainWindow = new MainWindow();
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/VoiceChatApp/MainWindow.axaml
+++ b/VoiceChatApp/MainWindow.axaml
@@ -1,0 +1,21 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="300"
+        x:Class="VoiceChatApp.MainWindow"
+        Title="Voice Chat">
+    <StackPanel Margin="10" Spacing="5">
+        <TextBlock Text="Remote IP:"/>
+        <TextBox Name="RemoteIpBox" Width="200"/>
+        <TextBlock Text="Remote Port:"/>
+        <TextBox Name="RemotePortBox" Width="100"/>
+        <TextBlock Text="Local Port:"/>
+        <TextBox Name="LocalPortBox" Width="100"/>
+        <StackPanel Orientation="Horizontal" Spacing="5" Margin="0,10,0,0">
+            <Button Name="StartButton" Content="Start" Click="OnStart" Width="80"/>
+            <Button Name="StopButton" Content="Stop" Click="OnStop" Width="80" IsEnabled="False"/>
+        </StackPanel>
+        <TextBlock Name="StatusText" Margin="0,10,0,0"/>
+    </StackPanel>
+</Window>

--- a/VoiceChatApp/MainWindow.axaml.cs
+++ b/VoiceChatApp/MainWindow.axaml.cs
@@ -1,0 +1,43 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace VoiceChatApp;
+
+public partial class MainWindow : Window
+{
+    private VoiceChatService? _service;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void OnStart(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            string remoteIp = RemoteIpBox.Text ?? "";
+            int remotePort = int.Parse(RemotePortBox.Text ?? "0");
+            int localPort = int.Parse(LocalPortBox.Text ?? "0");
+            _service = new VoiceChatService(remoteIp, remotePort, localPort);
+            _service.Start();
+            StatusText.Text = "Running";
+            StartButton.IsEnabled = false;
+            StopButton.IsEnabled = true;
+        }
+        catch (Exception ex)
+        {
+            StatusText.Text = ex.Message;
+        }
+    }
+
+    private void OnStop(object? sender, RoutedEventArgs e)
+    {
+        _service?.Dispose();
+        _service = null;
+        StatusText.Text = "Stopped";
+        StartButton.IsEnabled = true;
+        StopButton.IsEnabled = false;
+    }
+}

--- a/VoiceChatApp/Program.cs
+++ b/VoiceChatApp/Program.cs
@@ -1,0 +1,21 @@
+﻿using Avalonia;
+using System;
+
+namespace VoiceChatApp;
+
+class Program
+{
+    // Initialization code. Don't use any Avalonia, third-party APIs or any
+    // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
+    // yet and stuff might break.
+    [STAThread]
+    public static void Main(string[] args) => BuildAvaloniaApp()
+        .StartWithClassicDesktopLifetime(args);
+
+    // Avalonia configuration, don't remove; also used by visual designer.
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .WithInterFont()
+            .LogToTrace();
+}

--- a/VoiceChatApp/VoiceChatApp.csproj
+++ b/VoiceChatApp/VoiceChatApp.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="11.3.2" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.2" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.2" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.2" />
+    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.2">
+      <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
+      <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="NAudio" Version="2.2.1" />
+    <PackageReference Include="OpenTK" Version="4.9.4" />
+  </ItemGroup>
+</Project>

--- a/VoiceChatApp/VoiceChatService.cs
+++ b/VoiceChatApp/VoiceChatService.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using NAudio.Wave;
+
+namespace VoiceChatApp;
+
+public class VoiceChatService : IDisposable
+{
+    private readonly UdpClient _udp;
+    private readonly IPEndPoint _remote;
+    private readonly WaveInEvent _waveIn;
+    private readonly WaveOutEvent _waveOut;
+    private readonly BufferedWaveProvider _buffer;
+    private CancellationTokenSource? _cts;
+
+    public VoiceChatService(string remoteIp, int remotePort, int localPort)
+    {
+        _remote = new IPEndPoint(IPAddress.Parse(remoteIp), remotePort);
+        _udp = new UdpClient(localPort);
+
+        _waveIn = new WaveInEvent();
+        _waveIn.WaveFormat = new WaveFormat(16000, 16, 1);
+        _waveIn.DataAvailable += OnDataAvailable;
+
+        _buffer = new BufferedWaveProvider(_waveIn.WaveFormat);
+        _waveOut = new WaveOutEvent();
+        _waveOut.Init(_buffer);
+    }
+
+    private void OnDataAvailable(object? sender, WaveInEventArgs e)
+    {
+        _udp.Send(e.Buffer, e.BytesRecorded, _remote);
+    }
+
+    public void Start()
+    {
+        if (_cts != null) return;
+        _cts = new CancellationTokenSource();
+        _waveIn.StartRecording();
+        Task.Run(ReceiveLoop);
+    }
+
+    public void Stop()
+    {
+        if (_cts == null) return;
+        _cts.Cancel();
+        _waveIn.StopRecording();
+        _waveOut.Stop();
+        _cts = null;
+    }
+
+    private async Task ReceiveLoop()
+    {
+        var token = _cts!.Token;
+        while (!token.IsCancellationRequested)
+        {
+            var result = await _udp.ReceiveAsync(token);
+            _buffer.AddSamples(result.Buffer, 0, result.Buffer.Length);
+            if (_waveOut.PlaybackState != PlaybackState.Playing)
+                _waveOut.Play();
+        }
+    }
+
+    public void Dispose()
+    {
+        Stop();
+        _waveIn.Dispose();
+        _waveOut.Dispose();
+        _udp.Dispose();
+    }
+}

--- a/VoiceChatApp/app.manifest
+++ b/VoiceChatApp/app.manifest
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <!-- This manifest is used on Windows only.
+       Don't remove it as it might cause problems with window transparency and embedded controls.
+       For more details visit https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
+  <assemblyIdentity version="1.0.0.0" name="VoiceChatApp.Desktop"/>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>


### PR DESCRIPTION
## Summary
- add Avalonia app template
- implement `VoiceChatService` using UDP and NAudio
- wire up simple UI to start/stop voice chat

## Testing
- `dotnet build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68792b2d3d58832db561c18a2c589c8a